### PR TITLE
Add blockNumber

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ It returns an object representing the connected account (“wallet”), containi
 
 - `account`: the address of the account, or `null` when disconnected.
 - `activate(connectorId)`: call this function with a connector ID to “connect” to a provider (see above for the connectors provided by default).
+- `activating`: which provider is currently waiting to be activated. `null` otherwise.
 - `balance`: the balance of the account, in wei.
 - `connected`: whether the account is connected or not (same as testing `account !== null`).
 - `connectors`: the full list of connectors.

--- a/README.md
+++ b/README.md
@@ -46,23 +46,24 @@ import React from 'react'
 import { useWallet, UseWalletProvider } from 'use-wallet'
 
 function App() {
-  const { account, balance, connected, activate, deactivate } = useWallet()
+  const wallet = useWallet()
+  const blockNumber = wallet.getBlockNumber()
 
   return (
     <>
       <h1>Wallet</h1>
-      {connected ? (
+      {wallet.connected ? (
         <div>
-          <div>Account: {account}</div>
-          <div>Balance: {balance}</div>
-          <button onClick={() => deactivate()}>disconnect</button>
+          <div>Account: {wallet.account}</div>
+          <div>Balance: {wallet.balance}</div>
+          <button onClick={() => wallet.deactivate()}>disconnect</button>
         </div>
       ) : (
         <div>
           Connect:
-          <button onClick={() => activate()}>MetaMask</button>
-          <button onClick={() => activate('frame')}>Frame</button>
-          <button onClick={() => activate('portis')}>Portis</button>
+          <button onClick={() => wallet.activate()}>MetaMask</button>
+          <button onClick={() => wallet.activate('frame')}>Frame</button>
+          <button onClick={() => wallet.activate('portis')}>Portis</button>
         </div>
       )}
     </>
@@ -93,10 +94,6 @@ This is the provider component. It should be placed above any component using `u
 
 The [Chain ID](https://chainid.network/) supported by the connection. Defaults to 1.
 
-#### watchBlockNumber
-
-Whether or not to watch the track the block number in every useWallet() hook. If set to `false`, the value of the `blockNumber` property will be `null`, and the parent component won’t re-render when a new bolck number arrives. Defaults to `true`.
-
 #### connectors
 
 The configuration of the different connectors. If a connector that requires a configuration gets used without, an error will be thrown.
@@ -118,7 +115,6 @@ This is the hook to be used throughought the app.
 
 It takes an optional object as a single param, containing the following:
 
-- `watchBlockNumber`: whether or not to watch the track the block number. If set to `false`, the value of the `blockNumber` property will be `null`, and the parent component won’t re-render when a new bolck number arrives. Defaults to the value specified on the provider.
 - `pollBalanceInterval`: the interval used to poll the wallet balance. Defaults to 2000.
 - `pollBlockNumberInterval`: the interval used to poll the block number. Defaults to 5000.
 
@@ -128,6 +124,7 @@ It returns an object representing the connected account (“wallet”), containi
 - `activate(connectorId)`: call this function with a connector ID to “connect” to a provider (see above for the connectors provided by default).
 - `activating`: which provider is currently waiting to be activated. `null` otherwise.
 - `balance`: the balance of the account, in wei.
+- `getBlockNumber()`: this function returns the current block number. This is a function because the block number updates often, which could triggers as many extra renders. Making an explicit call to get the block number allows `useWallet()` to avoid these extra renders when the block number is not needed.
 - `connected`: whether the account is connected or not (same as testing `account !== null`).
 - `connectors`: the full list of connectors.
 - `deactivate()`: call this function to “disconnect” from the current provider.

--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ This is the provider component. It should be placed above any component using `u
 
 The [Chain ID](https://chainid.network/) supported by the connection. Defaults to 1.
 
+#### watchBlockNumber
+
+Whether or not to watch the track the block number in every useWallet() hook. If set to `false`, the value of the `blockNumber` property will be `null`, and the parent component won’t re-render when a new bolck number arrives. Defaults to `true`.
+
 #### connectors
 
 The configuration of the different connectors. If a connector that requires a configuration gets used without, an error will be thrown.
@@ -110,7 +114,15 @@ See the [web3-react documentation](https://github.com/NoahZinsmeister/web3-react
 
 ### useWallet()
 
-This is the hook to be used throughought the app. It returns an object representing the connected account (“wallet”), containing:
+This is the hook to be used throughought the app.
+
+It takes an optional object as a single param, containing the following:
+
+- `watchBlockNumber`: whether or not to watch the track the block number. If set to `false`, the value of the `blockNumber` property will be `null`, and the parent component won’t re-render when a new bolck number arrives. Defaults to the value specified on the provider.
+- `pollBalanceInterval`: the interval used to poll the wallet balance. Defaults to 2000.
+- `pollBlockNumberInterval`: the interval used to poll the block number. Defaults to 5000.
+
+It returns an object representing the connected account (“wallet”), containing:
 
 - `account`: the address of the account, or `null` when disconnected.
 - `activate(connectorId)`: call this function with a connector ID to “connect” to a provider (see above for the connectors provided by default).

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ It returns an object representing the connected account (“wallet”), containi
 - `connectors`: the full list of connectors.
 - `deactivate()`: call this function to “disconnect” from the current provider.
 - `ethereum`: the connected [Ethereum provider](https://eips.ethereum.org/EIPS/eip-1193).
+- `isContract`: whether or not the account is a contract.
 - `networkName`: a human-readable name corresponding to the Chain ID.
 
 ## Special thanks

--- a/examples/simple-connect/index.js
+++ b/examples/simple-connect/index.js
@@ -32,6 +32,10 @@ function App() {
     <>
       <h1>use-wallet</h1>
 
+      <p>
+        <span>Block: {wallet.blockNumber}</span>
+      </p>
+
       {(() => {
         if (lastError) {
           return (

--- a/examples/simple-connect/index.js
+++ b/examples/simple-connect/index.js
@@ -14,6 +14,7 @@ const { providers: EthersProviders, utils, EtherSymbol } = ethers
 function App() {
   const [lastError, setLastError] = useState('')
   const wallet = useWallet()
+  const blockNumber = wallet.getBlockNumber()
 
   const activate = async connector => {
     setLastError('')
@@ -93,7 +94,7 @@ function App() {
 
       {wallet.connected && (
         <p>
-          <span>Block:</span> <span>{wallet.blockNumber || '…'}</span>
+          <span>Block:</span> <span>{blockNumber || '…'}</span>
         </p>
       )}
     </>

--- a/examples/simple-connect/index.js
+++ b/examples/simple-connect/index.js
@@ -32,10 +32,6 @@ function App() {
     <>
       <h1>use-wallet</h1>
 
-      <p>
-        <span>Block: {wallet.blockNumber}</span>
-      </p>
-
       {(() => {
         if (lastError) {
           return (
@@ -46,10 +42,19 @@ function App() {
           )
         }
 
+        if (wallet.activating) {
+          return (
+            <p>
+              <span>Connecting to {wallet.activating}…</span>
+              <button onClick={() => wallet.deactivate()}>cancel</button>
+            </p>
+          )
+        }
+
         if (wallet.connected) {
           return (
             <p>
-              <span>Connected:</span>
+              <span>Connected.</span>
               <button onClick={() => wallet.deactivate()}>disconnect</button>
             </p>
           )
@@ -80,9 +85,15 @@ function App() {
           <span>Balance:</span>
           <span>
             {wallet.balance === '-1'
-              ? 'Unknown'
+              ? '…'
               : `${utils.formatEther(wallet.balance)} ETH`}
           </span>
+        </p>
+      )}
+
+      {wallet.connected && (
+        <p>
+          <span>Block:</span> <span>{wallet.blockNumber || '…'}</span>
         </p>
       )}
     </>

--- a/src/index.js
+++ b/src/index.js
@@ -25,11 +25,9 @@ import {
   getBlockNumber,
   getNetworkName,
   pollEvery,
-  rpcResult,
 } from './utils'
 
 const NO_BALANCE = '-1'
-const POLL_BALANCE_INTERVAL = 1000
 
 const UseWalletContext = React.createContext(null)
 
@@ -97,7 +95,7 @@ function useWalletBalance({ account, ethereum, pollBalanceInterval }) {
             .catch(() => NO_BALANCE)
         },
         onResult(balance) {
-          if (balance !== lastBalance) {
+          if (!cancel && balance !== lastBalance) {
             lastBalance = balance
             onUpdate(balance)
           }
@@ -177,7 +175,7 @@ function useWatchBlockNumber({ ethereum, pollBlockNumberInterval }) {
       cancel = true
       stopPollingBlockNumber()
     }
-  }, [ethereum, pollBlockNumberInterval])
+  }, [ethereum, pollBlockNumberInterval, updateBlockNumber])
 
   return { addBlockNumberListener, removeBlockNumberListener }
 }
@@ -311,6 +309,7 @@ function UseWalletProvider({
       connectors,
       deactivate,
       ethereum,
+      isContract,
       networkName: getNetworkName(chainId),
     }),
     [
@@ -321,7 +320,9 @@ function UseWalletProvider({
       chainId,
       connected,
       connectors,
+      deactivate,
       ethereum,
+      isContract,
       web3ReactContext,
     ]
   )

--- a/src/utils.js
+++ b/src/utils.js
@@ -8,6 +8,34 @@ export function getNetworkName(chainId) {
   return 'Unknown'
 }
 
+export function rpcResult(response) {
+  // Some providers don’t wrap the response
+  if (response && response.jsonrpc) {
+    if (response.error) {
+      throw new Error(response.error)
+    }
+    return response.result
+  }
+  return response
+}
+
+export async function getAccountIsContract(ethereum, account) {
+  try {
+    const code = await ethereum.send('eth_getCode', [account]).then(rpcResult)
+    return code !== '0x'
+  } catch (err) {
+    return false
+  }
+}
+
+export async function getAccountBalance(ethereum, account) {
+  return ethereum.send('eth_getBalance', [account, 'latest']).then(rpcResult)
+}
+
+export async function getBlockNumber(ethereum) {
+  return ethereum.send('eth_blockNumber', []).then(rpcResult)
+}
+
 export function pollEvery(fn, delay) {
   let timer = -1
   let stop = false


### PR DESCRIPTION
## Initial proposal

~Following the idea of keeping it “all in one hook”, the `blockNumber` is part of `useWallet()` rather than being a separate hook.~

~But there are two ways to disable this behavior and prevent unnecessary rerenders:~

- ~By setting `<UseWalletProvider watchBlockNumber={false} />` on the provider, which will disable it by default.~
- ~By setting `useWallet({ watchBlockNumber: false })` on the hook params, which will disable it for a given hook.~

~When disabled by default, it can also be enabled for a given hook by using `useWallet({ watchBlockNumber: false })`.~

## New proposal

Found a way to make it much simpler for users. Doing this will listen to the block number:

```jsx
const wallet = useWallet()
const blockNumber = wallet.getBlockNumber()
```

And if `getBlockNumber()` doesn’t get called, the component won’t do any extra render.

## Also

- Move most of the things into the provider, to remove extra work from the hook.
- Prevent useWallet() to get used without the provider.
- Prevent to use more than one provider.
- Split in hooks.