### PR TITLE
CI: add build/lint CI config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+on: push
+name: CI
+jobs:
+  CI:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install node
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12
+    - name: npm install
+      run: npm install
+    - name: npm build
+      run: npm run build
+    - name: npm test
+      run: npm run test
+    env:
+      CI: true


### PR DESCRIPTION
Adds a CI config for building and testing (at this time, only linting) on every PR.