### PR TITLE
API: Add ProvidedConnector and its configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,11 +113,6 @@ Configuration for the different connectors. If you use a connector that requires
 
 See the [web3-react documentation](https://github.com/NoahZinsmeister/web3-react/tree/v6/docs) for more details.
 
-#### ethereum
-
-An [EIP-1193](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1193.md) compatible provider
-object. This prop is optional.
-
 ### useWallet()
 
 This is the hook to be used throughout the app.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ export default () => (
 
 ### &lt;UseWalletProvider />
 
-This is the provider component. It should be placed above any component using `useWallet()`. Apart from `children`, it accepts three other props:
+This is the provider component. It should be placed above any component using `useWallet()`. Apart from `children`, it accepts two other props:
 
 #### chainId
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ export default () => (
 
 ### &lt;UseWalletProvider />
 
-This is the provider component. It should be placed above any component using `useWallet()`. Apart from `children`, it accepts two other props:
+This is the provider component. It should be placed above any component using `useWallet()`. Apart from `children`, it accepts three other props:
 
 #### chainId
 
@@ -112,6 +112,11 @@ Configuration for the different connectors. If you use a connector that requires
 - `walletlink`: `{ url, appName, appLogoUrl }`
 
 See the [web3-react documentation](https://github.com/NoahZinsmeister/web3-react/tree/v6/docs) for more details.
+
+#### ethereum
+
+An [EIP-1193](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1193.md) compatible provider
+object. This prop is optional.
 
 ### useWallet()
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "prepublishOnly": "git push && git push --tags"
   },
   "dependencies": {
+    "@aragon/provided-connector": "^6.0.7",
     "@web3-react/authereum-connector": "^6.1.1",
     "@web3-react/core": "^6.1.1",
     "@web3-react/fortmatic-connector": "^6.0.9",

--- a/src/connectors.js
+++ b/src/connectors.js
@@ -60,7 +60,7 @@ export function getConnectors(chainId, connectorsInitsOrConfigs = {}) {
         }
         if (err.message.startsWith('JSON.parse')) {
           throw new Error(
-            'There seem to be an issue when trying to connect to Frame.'
+            'There seems to be an issue when trying to connect to Frame.'
           )
         }
       },

--- a/src/connectors.js
+++ b/src/connectors.js
@@ -22,11 +22,7 @@ import {
 // TODO: fix babel-runtime issue with torus-connector
 import { TorusConnector } from '@web3-react/torus-connector'
 
-export function getConnectors(
-  chainId,
-  connectorsInitsOrConfigs = {},
-  ethereum
-) {
+export function getConnectors(chainId, connectorsInitsOrConfigs = {}) {
   // Split the connector initializers from the confs.
   const [inits, configs] = Object.entries(connectorsInitsOrConfigs).reduce(
     ([inits, configs], [id, initOrConfig]) => {
@@ -44,7 +40,6 @@ export function getConnectors(
     injected: {
       web3ReactConnector({ chainId, providedEthereum }) {
         return new InjectedConnector({
-          ethereum,
           provider: providedEthereum,
           supportedChainIds: [chainId],
         })

--- a/src/connectors.js
+++ b/src/connectors.js
@@ -13,7 +13,7 @@ import { PortisConnector } from '@web3-react/portis-connector'
 import {
   ProvidedConnector,
   UserRejectedRequestError as ProvidedUserRejectedRequestError,
-} from '@web3-react/provided-connector'
+} from '@aragon/provided-connector'
 import { SquarelinkConnector } from '@web3-react/squarelink-connector'
 import { WalletLinkConnector } from '@web3-react/walletlink-connector'
 import { RejectedActivationError, ConnectorConfigError } from './errors'

--- a/src/connectors.js
+++ b/src/connectors.js
@@ -5,6 +5,10 @@ import {
   UserRejectedRequestError as FrameUserRejectedRequestError,
 } from '@web3-react/frame-connector'
 import {
+  ProvidedConnector,
+  UserRejectedRequestError as ProvidedUserRejectedRequestError,
+} from '@web3-react/provided-connector'
+import {
   InjectedConnector,
   // NoEthereumProviderError as InjectedNoEthereumProviderError,
   UserRejectedRequestError as InjectedUserRejectedRequestError,
@@ -38,11 +42,8 @@ export function getConnectors(chainId, connectorsInitsOrConfigs = {}) {
 
   const connectors = {
     injected: {
-      web3ReactConnector({ chainId, providedEthereum }) {
-        return new InjectedConnector({
-          provider: providedEthereum,
-          supportedChainIds: [chainId],
-        })
+      web3ReactConnector({ chainId }) {
+        return new InjectedConnector({ supportedChainIds: [chainId] })
       },
       handleActivationError(err) {
         if (err instanceof InjectedUserRejectedRequestError) {
@@ -83,6 +84,14 @@ export function getConnectors(chainId, connectorsInitsOrConfigs = {}) {
           )
         }
         return new PortisConnector({ dAppId, networks: [chainId] })
+      },
+    },
+    provided: {
+      web3ReactConnector({ chainId, provider }) {
+        return new ProvidedConnector({
+          provider,
+          supportedChainIds: [chainId],
+        })
       },
     },
     authereum: {

--- a/src/connectors.js
+++ b/src/connectors.js
@@ -22,7 +22,11 @@ import {
 // TODO: fix babel-runtime issue with torus-connector
 import { TorusConnector } from '@web3-react/torus-connector'
 
-export function getConnectors(chainId, connectorsInitsOrConfigs = {}) {
+export function getConnectors(
+  chainId,
+  connectorsInitsOrConfigs = {},
+  ethereum
+) {
   // Split the connector initializers from the confs.
   const [inits, configs] = Object.entries(connectorsInitsOrConfigs).reduce(
     ([inits, configs], [id, initOrConfig]) => {
@@ -38,8 +42,12 @@ export function getConnectors(chainId, connectorsInitsOrConfigs = {}) {
 
   const connectors = {
     injected: {
-      web3ReactConnector({ chainId }) {
-        return new InjectedConnector({ supportedChainIds: [chainId] })
+      web3ReactConnector({ chainId, providedEthereum }) {
+        return new InjectedConnector({
+          ethereum,
+          provider: providedEthereum,
+          supportedChainIds: [chainId],
+        })
       },
       handleActivationError(err) {
         if (err instanceof InjectedUserRejectedRequestError) {

--- a/src/connectors.js
+++ b/src/connectors.js
@@ -1,3 +1,7 @@
+import {
+  ProvidedConnector,
+  UserRejectedRequestError as ProvidedUserRejectedRequestError,
+} from '@aragon/provided-connector'
 import { AuthereumConnector } from '@web3-react/authereum-connector'
 import { FortmaticConnector } from '@web3-react/fortmatic-connector'
 import {
@@ -10,10 +14,6 @@ import {
   UserRejectedRequestError as InjectedUserRejectedRequestError,
 } from '@web3-react/injected-connector'
 import { PortisConnector } from '@web3-react/portis-connector'
-import {
-  ProvidedConnector,
-  UserRejectedRequestError as ProvidedUserRejectedRequestError,
-} from '@aragon/provided-connector'
 import { SquarelinkConnector } from '@web3-react/squarelink-connector'
 import { WalletLinkConnector } from '@web3-react/walletlink-connector'
 import { RejectedActivationError, ConnectorConfigError } from './errors'

--- a/src/connectors.js
+++ b/src/connectors.js
@@ -5,15 +5,15 @@ import {
   UserRejectedRequestError as FrameUserRejectedRequestError,
 } from '@web3-react/frame-connector'
 import {
-  ProvidedConnector,
-  UserRejectedRequestError as ProvidedUserRejectedRequestError,
-} from '@web3-react/provided-connector'
-import {
   InjectedConnector,
   // NoEthereumProviderError as InjectedNoEthereumProviderError,
   UserRejectedRequestError as InjectedUserRejectedRequestError,
 } from '@web3-react/injected-connector'
 import { PortisConnector } from '@web3-react/portis-connector'
+import {
+  ProvidedConnector,
+  UserRejectedRequestError as ProvidedUserRejectedRequestError,
+} from '@web3-react/provided-connector'
 import { SquarelinkConnector } from '@web3-react/squarelink-connector'
 import { WalletLinkConnector } from '@web3-react/walletlink-connector'
 import { RejectedActivationError, ConnectorConfigError } from './errors'
@@ -92,6 +92,11 @@ export function getConnectors(chainId, connectorsInitsOrConfigs = {}) {
           provider,
           supportedChainIds: [chainId],
         })
+      },
+      handleActivationError(err) {
+        if (err instanceof ProvidedUserRejectedRequestError) {
+          throw new RejectedActivationError()
+        }
       },
     },
     authereum: {

--- a/src/index.js
+++ b/src/index.js
@@ -191,7 +191,6 @@ function UseWalletProvider({
   connectors: connectorsInitsOrConfigs,
   pollBalanceInterval,
   pollBlockNumberInterval,
-  providedEthereum,
 }) {
   const walletContext = useContext(UseWalletContext)
 
@@ -249,7 +248,6 @@ function UseWalletProvider({
         connector.web3ReactConnector &&
         connector.web3ReactConnector({
           chainId,
-          providedEthereum,
           ...(connector.config || {}),
         })
 
@@ -282,7 +280,7 @@ function UseWalletProvider({
         throw err
       }
     },
-    [chainId, connectors, deactivate, providedEthereum, web3ReactContext]
+    [chainId, connectors, deactivate, web3ReactContext]
   )
 
   useEffect(() => {

--- a/src/index.js
+++ b/src/index.js
@@ -337,19 +337,17 @@ function UseWalletProvider({
   )
 
   return (
-    <Web3ReactProvider getLibrary={ethereum => ethereum}>
-      <UseWalletContext.Provider
-        value={{
-          addBlockNumberListener,
-          pollBalanceInterval,
-          pollBlockNumberInterval,
-          removeBlockNumberListener,
-          wallet,
-        }}
-      >
-        {children}
-      </UseWalletContext.Provider>
-    </Web3ReactProvider>
+    <UseWalletContext.Provider
+      value={{
+        addBlockNumberListener,
+        pollBalanceInterval,
+        pollBlockNumberInterval,
+        removeBlockNumberListener,
+        wallet,
+      }}
+    >
+      {children}
+    </UseWalletContext.Provider>
   )
 }
 
@@ -368,9 +366,13 @@ UseWalletProvider.defaultProps = {
   pollBlockNumberInterval: 5000,
 }
 
-function UseWalletProviderWrapper(props) {
+function UseWalletProviderWrapper({ ethereum: providedEthereum, ...props }) {
+  const getLibrary = useCallback(ethereum => providedEthereum || ethereum, [
+    providedEthereum,
+  ])
+
   return (
-    <Web3ReactProvider getLibrary={ethereum => ethereum}>
+    <Web3ReactProvider getLibrary={getLibrary}>
       <UseWalletProvider {...props} />
     </Web3ReactProvider>
   )

--- a/src/index.js
+++ b/src/index.js
@@ -370,7 +370,7 @@ UseWalletProvider.defaultProps = {
   pollBlockNumberInterval: 5000,
 }
 
-function UseWalletProviderWrapper({ ...props }) {
+function UseWalletProviderWrapper(props) {
   return (
     <Web3ReactProvider getLibrary={ethereum => ethereum}>
       <UseWalletProvider {...props} />

--- a/src/index.js
+++ b/src/index.js
@@ -191,6 +191,7 @@ function UseWalletProvider({
   connectors: connectorsInitsOrConfigs,
   pollBalanceInterval,
   pollBlockNumberInterval,
+  providedEthereum,
 }) {
   const walletContext = useContext(UseWalletContext)
 
@@ -205,7 +206,6 @@ function UseWalletProvider({
   const web3ReactContext = useWeb3React()
   const activationId = useRef(0)
   const { account, library: ethereum } = web3ReactContext
-
   const balance = useWalletBalance({ account, ethereum, pollBalanceInterval })
   const {
     addBlockNumberListener,
@@ -214,8 +214,8 @@ function UseWalletProvider({
 
   // Combine the user-provided connectors with the default ones (see connectors.js).
   const connectors = useMemo(
-    () => getConnectors(chainId, connectorsInitsOrConfigs),
-    [chainId, connectorsInitsOrConfigs]
+    () => getConnectors(chainId, connectorsInitsOrConfigs, providedEthereum),
+    [chainId, connectorsInitsOrConfigs, providedEthereum]
   )
 
   const deactivate = useCallback(async () => {
@@ -247,7 +247,11 @@ function UseWalletProvider({
       const web3ReactConnector =
         connector &&
         connector.web3ReactConnector &&
-        connector.web3ReactConnector({ chainId, ...(connector.config || {}) })
+        connector.web3ReactConnector({
+          chainId,
+          providedEthereum,
+          ...(connector.config || {}),
+        })
 
       if (!web3ReactConnector) {
         throw new UnsupportedConnectorError(connectorId)
@@ -278,7 +282,7 @@ function UseWalletProvider({
         throw err
       }
     },
-    [chainId, connectors, web3ReactContext, deactivate]
+    [chainId, connectors, deactivate, providedEthereum, web3ReactContext]
   )
 
   useEffect(() => {
@@ -373,7 +377,7 @@ function UseWalletProviderWrapper({ ethereum: providedEthereum, ...props }) {
 
   return (
     <Web3ReactProvider getLibrary={getLibrary}>
-      <UseWalletProvider {...props} />
+      <UseWalletProvider providedEthereum={providedEthereum} {...props} />
     </Web3ReactProvider>
   )
 }

--- a/src/index.js
+++ b/src/index.js
@@ -370,14 +370,10 @@ UseWalletProvider.defaultProps = {
   pollBlockNumberInterval: 5000,
 }
 
-function UseWalletProviderWrapper({ ethereum: providedEthereum, ...props }) {
-  const getLibrary = useCallback(ethereum => providedEthereum || ethereum, [
-    providedEthereum,
-  ])
-
+function UseWalletProviderWrapper({ ...props }) {
   return (
-    <Web3ReactProvider getLibrary={getLibrary}>
-      <UseWalletProvider providedEthereum={providedEthereum} {...props} />
+    <Web3ReactProvider getLibrary={ethereum => ethereum}>
+      <UseWalletProvider {...props} />
     </Web3ReactProvider>
   )
 }

--- a/src/index.js
+++ b/src/index.js
@@ -214,8 +214,8 @@ function UseWalletProvider({
 
   // Combine the user-provided connectors with the default ones (see connectors.js).
   const connectors = useMemo(
-    () => getConnectors(chainId, connectorsInitsOrConfigs, providedEthereum),
-    [chainId, connectorsInitsOrConfigs, providedEthereum]
+    () => getConnectors(chainId, connectorsInitsOrConfigs),
+    [chainId, connectorsInitsOrConfigs]
   )
 
   const deactivate = useCallback(async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,15 @@
 # yarn lockfile v1
 
 
+"@aragon/provided-connector@^6.0.7":
+  version "6.0.7"
+  resolved "https://registry.yarnpkg.com/@aragon/provided-connector/-/provided-connector-6.0.7.tgz#dbe368ed8c097017719d37afc4f718591b16fd3f"
+  integrity sha512-DheBuw+mSs/3VGoQqa8BlVpYRR0jW3sydhKKiqsEC17KRLOhISZYslrD3it93ZPtd3B9ap0qGbfZxaseP0O3uQ==
+  dependencies:
+    "@web3-react/abstract-connector" "^6.0.7"
+    "@web3-react/types" "^6.0.7"
+    tiny-warning "^1.0.3"
+
 "@babel/cli@^7.8.3":
   version "7.8.4"
   resolved "https://registry.yarnpkg.com/@babel/cli/-/cli-7.8.4.tgz#505fb053721a98777b2b175323ea4f090b7d3c1c"


### PR DESCRIPTION
Due to the client local connection fix, we've decided to add a new connector called `ProvidedConnector` coming from web3-react, which will allow us to provide our own `EIP-1193` compatible provider object.

This also removes a `Web3ReactProvider` that was unneeded and therefore overriding the top-level one.