### PR TITLE
Add an option to overwrite the etherium provider for unit testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ export default () => (
 
 ### &lt;UseWalletProvider />
 
-This is the provider component. It should be placed above any component using `useWallet()`. Apart from `children`, it accepts two other props:
+This is the provider component. It should be placed above any component using `useWallet()`. Apart from `children`, it accepts three other props:
 
 #### chainId
 
@@ -114,14 +114,26 @@ Configuration for the different connectors. If you use a connector that requires
 
 See the [web3-react documentation](https://github.com/NoahZinsmeister/web3-react/tree/v6/docs) for more details.
 
+#### pollBalanceInterval
+
+The interval used to poll the wallet balance. Defaults to 2000.
+
+#### pollBalanceInterval
+
+The interval used to poll the wallet balance. Defaults to 2000.
+
+#### getCustomEtheriumProvider
+
+Useful for mocking the underlying etherium provider in unit tests. Otherwise don't change this.
+
 ### useWallet()
 
 This is the hook to be used throughout the app.
 
 It takes an optional object as a single param, containing the following:
 
-- `pollBalanceInterval`: the interval used to poll the wallet balance. Defaults to 2000.
-- `pollBlockNumberInterval`: the interval used to poll the block number. Defaults to 5000.
+- `pollBalanceInterval`: the interval used to poll the wallet balance. Defaults to 2000. Overrides the setting in UseWalletProvider.
+- `pollBlockNumberInterval`: the interval used to poll the block number. Defaults to 5000. Overrides the setting in UseWalletProvider.
 
 It returns an object representing the connected account (“wallet”), containing:
 

--- a/README.md
+++ b/README.md
@@ -116,11 +116,11 @@ See the [web3-react documentation](https://github.com/NoahZinsmeister/web3-react
 
 #### pollBalanceInterval
 
-The interval used to poll the wallet balance. Defaults to 2000.
+The interval used to poll the wallet balance. Defaults to 2000. Setting this to a negative number will disable polling.
 
-#### pollBalanceInterval
+#### pollBlockNumberInterval
 
-The interval used to poll the wallet balance. Defaults to 2000.
+The interval used to poll the block number. Defaults to 5000. Setting this to a negative number will disable polling.
 
 #### getCustomEtheriumProvider
 

--- a/src/index.js
+++ b/src/index.js
@@ -91,7 +91,9 @@ function useWalletBalance({ account, ethereum, pollBalanceInterval }) {
       return {
         async request() {
           return getAccountBalance(ethereum, account)
-            .then(value => (value ? JSBI.BigInt(value).toString() : NO_BALANCE))
+            .then((value) =>
+              value ? JSBI.BigInt(value).toString() : NO_BALANCE
+            )
             .catch(() => NO_BALANCE)
         },
         onResult(balance) {
@@ -124,7 +126,7 @@ function useWatchBlockNumber({ ethereum, pollBlockNumberInterval }) {
   // number, which implies to re-render whenever the block number updates.
   const blockNumberListeners = useRef(new Set())
 
-  const addBlockNumberListener = useCallback(cb => {
+  const addBlockNumberListener = useCallback((cb) => {
     if (blockNumberListeners.current.has(cb)) {
       return
     }
@@ -136,18 +138,18 @@ function useWatchBlockNumber({ ethereum, pollBlockNumberInterval }) {
     blockNumberListeners.current.add(cb)
   }, [])
 
-  const removeBlockNumberListener = useCallback(cb => {
+  const removeBlockNumberListener = useCallback((cb) => {
     blockNumberListeners.current.delete(cb)
   }, [])
 
   // Update the block number and broadcast it to the listeners
-  const updateBlockNumber = useCallback(blockNumber => {
+  const updateBlockNumber = useCallback((blockNumber) => {
     if (lastBlockNumber.current === blockNumber) {
       return
     }
 
     lastBlockNumber.current = blockNumber
-    blockNumberListeners.current.forEach(cb => cb(blockNumber))
+    blockNumberListeners.current.forEach((cb) => cb(blockNumber))
   }, [])
 
   useEffect(() => {
@@ -161,7 +163,7 @@ function useWatchBlockNumber({ ethereum, pollBlockNumberInterval }) {
     const pollBlockNumber = pollEvery(() => {
       return {
         request: () => getBlockNumber(ethereum),
-        onResult: latestBlockNumber => {
+        onResult: (latestBlockNumber) => {
           if (!cancel) {
             updateBlockNumber(
               latestBlockNumber === null
@@ -309,7 +311,7 @@ function UseWalletProvider({
 
     setType(null)
 
-    getAccountIsContract(ethereum, account).then(isContract => {
+    getAccountIsContract(ethereum, account).then((isContract) => {
       if (!cancel) {
         setStatus('connected')
         setType(isContract ? 'contract' : 'normal')
@@ -386,15 +388,22 @@ UseWalletProvider.defaultProps = {
 }
 
 function UseWalletProviderWrapper(props) {
+  const { getCustomEtheriumProvider, ...otherProps } = props
   return (
-    <Web3ReactProvider getLibrary={ethereum => ethereum}>
-      <UseWalletProvider {...props} />
+    <Web3ReactProvider getLibrary={getCustomEtheriumProvider}>
+      <UseWalletProvider {...otherProps} />
     </Web3ReactProvider>
   )
 }
 
-UseWalletProviderWrapper.propTypes = UseWalletProvider.propTypes
-UseWalletProviderWrapper.defaultProps = UseWalletProvider.defaultProps
+UseWalletProviderWrapper.propTypes = {
+  ...UseWalletProvider.propTypes,
+  getCustomEtheriumProvider: PropTypes.func,
+}
+UseWalletProviderWrapper.defaultProps = {
+  ...UseWalletProvider.defaultProps,
+  getCustomEtheriumProvider: (ethereum) => ethereum,
+}
 
 export {
   ConnectionRejectedError,

--- a/src/utils.js
+++ b/src/utils.js
@@ -80,6 +80,10 @@ export async function getBlockNumber(ethereum) {
 }
 
 export function pollEvery(fn, delay) {
+  if delay < 0 {
+    return () => ()
+  }
+  
   let timer = -1
   let stop = false
   const poll = async (request, onResult) => {


### PR DESCRIPTION
Currently, when using a use-wallet, you can't mock out the provider for unit tests. This fixes that. 

Also, my prettier formatter got a hold of it, so let me know if this is something you want to do, then I'll take out the extra code. 