### PR TITLE
add bsc connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ useWallet() allows dapp users to connect to the provider of their choice in a wa
 Oh yes:
 
 - React only.
-- Ethereum only (for now).
+- Ethereum and Binance Smart Chain only (for now).
 - Supports one network at a time.
 - Embeds as many providers as possible.
 - Every prop and parameter is optional.
@@ -111,6 +111,7 @@ Configuration for the different connectors. If you use a connector that requires
 - `squarelink`: `{ clientId, options }`
 - `walletconnect`: `{ rpcUrl }`
 - `walletlink`: `{ url, appName, appLogoUrl }`
+- `bsc`: no configuration needed.
 
 See the [web3-react documentation](https://github.com/NoahZinsmeister/web3-react/tree/v6/docs) for more details.
 

--- a/examples/nextjs/pages/index.js
+++ b/examples/nextjs/pages/index.js
@@ -53,6 +53,7 @@ function App() {
             <div className="connect-label">Connect:</div>
             <div className="connect-buttons">
               <button onClick={() => activate('injected')}>injected</button>
+              <button onClick={() => activate('bsc')}>bsc</button>
               <button onClick={() => activate('frame')}>frame</button>
               <button onClick={() => activate('portis')}>portis</button>
               <button onClick={() => activate('fortmatic')}>fortmatic</button>

--- a/examples/simple-connect/index.js
+++ b/examples/simple-connect/index.js
@@ -57,6 +57,7 @@ function App() {
             <div className="connect-label">Connect:</div>
             <div className="connect-buttons">
               <button onClick={() => activate('injected')}>injected</button>
+              <button onClick={() => activate('bsc')}>bsc</button>
               <button onClick={() => activate('frame')}>frame</button>
               <button onClick={() => activate('portis')}>portis</button>
               <button onClick={() => activate('fortmatic')}>fortmatic</button>

--- a/examples/web3-js-compat/index.js
+++ b/examples/web3-js-compat/index.js
@@ -56,6 +56,7 @@ function App() {
             <div className="connect-label">Connect:</div>
             <div className="connect-buttons">
               <button onClick={() => activate('injected')}>injected</button>
+              <button onClick={() => activate('bsc')}>bsc</button>
               <button onClick={() => activate('frame')}>frame</button>
               <button onClick={() => activate('portis')}>portis</button>
               <button onClick={() => activate('fortmatic')}>fortmatic</button>

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@aragon/provided-connector": "^6.0.7",
+    "@binance-chain/bsc-connector": "^1.0.3",
     "@web3-react/authereum-connector": "^6.1.1",
     "@web3-react/core": "^6.1.1",
     "@web3-react/fortmatic-connector": "^6.0.9",

--- a/src/connectors.js
+++ b/src/connectors.js
@@ -16,6 +16,7 @@ import {
 import { PortisConnector } from '@web3-react/portis-connector'
 import { SquarelinkConnector } from '@web3-react/squarelink-connector'
 import { WalletLinkConnector } from '@web3-react/walletlink-connector'
+import { BscConnector } from '@web3-react/bsc-connector'
 import { ConnectionRejectedError, ConnectorConfigError } from './errors'
 
 import {
@@ -160,6 +161,16 @@ export function getConnectors(chainId, connectorsInitsOrConfigs = {}) {
           )
         }
         return new WalletLinkConnector({ url, appName, appLogoUrl })
+      },
+    },
+    bsc: {
+      web3ReactConnector({ chainId }) {
+        return new BscConnector({ supportedChainIds: [chainId] })
+      },
+      handleActivationError(err) {
+        if (err instanceof InjectedUserRejectedRequestError) {
+          return new ConnectionRejectedError()
+        }
       },
     },
     ...inits,

--- a/src/connectors.js
+++ b/src/connectors.js
@@ -16,7 +16,7 @@ import {
 import { PortisConnector } from '@web3-react/portis-connector'
 import { SquarelinkConnector } from '@web3-react/squarelink-connector'
 import { WalletLinkConnector } from '@web3-react/walletlink-connector'
-import { BscConnector } from '@web3-react/bsc-connector'
+import { BscConnector } from '@binance-chain/bsc-connector'
 import { ConnectionRejectedError, ConnectorConfigError } from './errors'
 
 import {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -16,6 +16,7 @@ declare module 'use-wallet' {
     }
     walletconnect: { rpcUrl: string }
     walletlink: { url: string; appName: string; appLogoUrl: string }
+    bsc: {}
   }>
 
   export interface Wallet<T> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -870,6 +870,15 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
+"@binance-chain/bsc-connector@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@binance-chain/bsc-connector/-/bsc-connector-1.0.3.tgz#63a3daf39acff68f07c9c8c4e59f44627c0802eb"
+  integrity sha512-f53UZhsov7r38gE8uuUiynif36T+/CvEdDu8rgpADVjzk/OfnSE60DMeei8IcqWBVO52r7PyohWjaAd3LT97xQ==
+  dependencies:
+    "@web3-react/abstract-connector" "^6.0.7"
+    "@web3-react/types" "^6.0.7"
+    tiny-warning "^1.0.3"
+
 "@chaitanyapotti/random-id@^1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@chaitanyapotti/random-id/-/random-id-1.0.3.tgz#f52f647cfe9f79fc7723ea2b01b0ad3889204002"


### PR DESCRIPTION
I raised a PR to web3-react library to add a bsc connector as a lot of dapp developer are asking for it: https://github.com/NoahZinsmeister/web3-react/pull/123

This one can be merged after it get merged. 

I manually tested with this piece of code:

```
import React, {useEffect} from 'react'
import { useWallet, UseWalletProvider } from 'use-wallet'

function App() {
  const wallet = useWallet()
  const blockNumber = wallet.getBlockNumber()

  useEffect(() => {
      console.log(wallet.ethereum);
      console.log(wallet.chainId);
      console.log(wallet.networkName);
      console.log(wallet.status);
      console.log(wallet.getBlockNumber());
  }, [wallet])

  return (
      <>
        <h1>Wallet</h1>
        {wallet.status === 'connected' ? (
            <div>
              <div>Account: {wallet.account}</div>
              <div>Balance: {wallet.balance}</div>
              <button onClick={() => wallet.reset()}>disconnect</button>
            </div>
        ) : (
            <div>
              Connect:
              <button onClick={() => wallet.connect()}>MetaMask</button>
              <button onClick={() => wallet.connect('bsc')}>Binance Chain Wallet</button>
            </div>
        )}
      </>
  )
}

// Wrap everything in <UseWalletProvider />
export default () => (
    <UseWalletProvider
        chainId={56}
        connectors={{
          // This is how connectors get configured
          bsc: { chainId: 56 },
        }}
    >
      <App />
    </UseWalletProvider>
)

```