### PR TITLE
Fix path for typescript definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "types": "dist/esm/index.d.ts",
+  "types": "dist/cjs/index.d.ts",
   "sideEffects": false,
   "files": [
     "dist"


### PR DESCRIPTION
"types" field in package.json incorrectly maps to esm folder, although types themselves are located in cjs one:

![image](https://user-images.githubusercontent.com/35937217/125205158-8e41b580-e289-11eb-9ff9-6dc94743bf14.png)


![image](https://user-images.githubusercontent.com/35937217/125205141-82ee8a00-e289-11eb-8afb-c53a2ef0884b.png)
