### PR TITLE
Use supportedChainIds option to allow BSC on WalletConnect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 yarn-error.log
 .yarn/cache
 .cache/
+.idea/

--- a/src/connectors/ConnectorWalletConnect.ts
+++ b/src/connectors/ConnectorWalletConnect.ts
@@ -31,6 +31,7 @@ export default async function init(): Promise<Connector> {
         bridge,
         pollingInterval,
         qrcode: true,
+        supportedChainIds: [chainId],
         rpc: { [chainId]: rpcUrl },
       })
     },


### PR DESCRIPTION
Right now, the workaround for using the WalletConnector in "useWallet" was providing a custom connector - however, to prevent this and just use the configuration a further configuration property "supportedChainIds" is needed. This option is provided in this pull request and sets it to the already existing configuration property "chainId" .