### PR TITLE
Allow react ^17

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "typescript": "^4.0.2"
   },
   "peerDependencies": {
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1"
+    "react": "^16.13.1 || ^17",
+    "react-dom": "^16.13.1 || ^17"
   }
 }


### PR DESCRIPTION
This updates the peerDependencies list for `react` and `react-dom` to allow `react ^17`, which is compatible with this package.

Fixes #162