### PR TITLE
Allow interacting with smart contracts (backwards compatible change)

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -114,6 +114,7 @@ type UseWalletProviderProps = {
   autoConnect: boolean
   pollBalanceInterval: number
   pollBlockNumberInterval: number
+  getLibrary?: (provider: any) => void
 }
 
 UseWalletProvider.propTypes = {
@@ -374,9 +375,14 @@ UseWalletProviderWrapper.propTypes = UseWalletProvider.propTypes
 UseWalletProviderWrapper.defaultProps = UseWalletProvider.defaultProps
 
 function UseWalletProviderWrapper(props: UseWalletProviderProps) {
+  const { getLibrary, ...restProps } = props
+  const getLibraryOrDefault = getLibrary
+    ? getLibrary
+    : (provider: any) => provider
+
   return (
-    <Web3ReactProvider getLibrary={(ethereum) => ethereum}>
-      <UseWalletProvider {...props} />
+    <Web3ReactProvider getLibrary={getLibraryOrDefault}>
+      <UseWalletProvider {...restProps} />
     </Web3ReactProvider>
   )
 }


### PR DESCRIPTION
Provider is null when using `web3-react` without this change.

```jsx
// how it's used
function getLibrary(provider: any) {
	return new ethers.providers.Web3Provider(provider);
}

...
// how it's used to interact with smart contracts
const web3ReactProvider = useWeb3React<Web3Provider>();
const libProvider = web3ReactProvider.library.provider; // library.provider is null without this change

const provider = new Web3Provider(libProvider);

const contract = new Contract(
	cotractAddress,
	new ethers.utils.Interface(json),
	provider
);

const result = await contract.totalSupply()
```