### PR TITLE
Add celo mainnet and alfajores testnet

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-wallet",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "author": "Aragon Association <legal@aragon.org>",
   "license": "MIT",
   "main": "dist/cjs/index.js",

--- a/src/chains.ts
+++ b/src/chains.ts
@@ -37,6 +37,12 @@ const BNB: Currency = {
   decimals: 18,
 }
 
+const CELO: Currency = {
+  name: 'Celo',
+  symbol: 'CELO',
+  decimals: 18,
+}
+
 const CHAIN_INFORMATION = new Map<number, ChainInformation | ChainType>([
   [
     1,
@@ -239,6 +245,30 @@ const CHAIN_INFORMATION = new Map<number, ChainInformation | ChainType>([
       shortName: 'Arbitrum',
       explorerUrl: 'https://arbiscan.io/',
       testnet: false,
+    },
+  ],
+  [
+    42220,
+    {
+      id: 42220,
+      nativeCurrency: CELO,
+      type: 'celo',
+      fullName: 'Celo (Mainnet)',
+      shortName: 'Celo',
+      explorerUrl: 'https://explorer.celo.org/',
+      testnet: false,
+    },
+  ],
+  [
+    44787,
+    {
+      id: 44787,
+      nativeCurrency: CELO,
+      type: 'celoTest',
+      fullName: 'Celo (Alfajores Testnet)',
+      shortName: 'Alfajores',
+      explorerUrl: 'https://alfajores-blockscout.celo-testnet.org/',
+      testnet: true,
     },
   ],
   [


### PR DESCRIPTION
From CELO [docs](https://docs.celo.org/getting-started/wallets/using-metamask-with-celo/manual-setup):

* Mainnet

```
Network Name: Celo (Mainnet)
New RPC URL: https://forno.celo.org
Chain ID: 42220
Currency Symbol (Optional): CELO
Block Explorer URL (Optional): https://explorer.celo.org
```

* Alfajores

```
Network Name: Celo (Alfajores Testnet)
New RPC URL: https://alfajores-forno.celo-testnet.org
Chain ID: 44787
Currency Symbol (Optional): CELO
Block Explorer URL (Optional): https://alfajores-blockscout.celo-testnet.org
```