### PR TITLE
Add support for Cronos chain 

### DIFF
--- a/src/chains.ts
+++ b/src/chains.ts
@@ -81,6 +81,11 @@ const HECO: Currency = {
   symbol: 'HT',
   decimals: 18,
 }
+const CRO: Currency = {
+  name: 'CRONOS',
+  symbol: 'CRO',
+  decimals: 18,
+}
 
 const CHAIN_INFORMATION = new Map<number, ChainInformation | ChainType>([
   [
@@ -455,6 +460,18 @@ const CHAIN_INFORMATION = new Map<number, ChainInformation | ChainType>([
       fullName: 'HECO Mainnet',
       shortName: 'HECO',
       explorerUrl: `https://hecoscan.xyz/`,
+      testnet: false,
+    },
+  ],
+  [
+    25,
+    {
+      id: 25,
+      nativeCurrency: CRO,
+      type: 'main',
+      fullName: 'Cronos Chain',
+      shortName: 'Cronos',
+      explorerUrl: `https://cronoscan.com`,
       testnet: false,
     },
   ],


### PR DESCRIPTION
This PR adds support for Cronos chain 

website: https://cronos.org/
official network setup guide: https://cronos.org/docs/getting-started/metamask.html#connecting-to-the-cronos-mainnet-beta

This PR fixes the error users are having when using `use-wallet` with Cronos chain #192 